### PR TITLE
Fix “sheet - loggedin - import file” test

### DIFF
--- a/e2e-tests/sheet_loggedin.spec.js
+++ b/e2e-tests/sheet_loggedin.spec.js
@@ -73,7 +73,7 @@ test('loggedin - sheet - import template', async ({ page, context }) => {
     await page.waitForTimeout(1000)
 
     const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
-    await page1.waitForTimeout(1000)
+    await page.waitForTimeout(1000);
 
     expect(clipboardText.trim()).toContain('example template content');
 


### PR DESCRIPTION
Typo in a variable name made the test consistently fail.